### PR TITLE
don't use Dancer2 ':syntax';

### DIFF
--- a/lib/Dancer2/Plugin/Res.pm
+++ b/lib/Dancer2/Plugin/Res.pm
@@ -17,7 +17,6 @@ use 5.006;
 use strict; use warnings;
 use Data::Dumper;
 
-use Dancer2 ':syntax';
 use Dancer2::Plugin;
 
 =head1 DESCRIPTION


### PR DESCRIPTION
With current master branch of Dancer2 (to be released soon) plugins
break if they import Dancer2 itself.
